### PR TITLE
Style changes to OpenButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run the demo app:
 
 ```
 npm i
-npm run cy
+npm run dev
 ```
 
 To run the demo app and Cypress tests together:

--- a/src/DevTools.tsx
+++ b/src/DevTools.tsx
@@ -165,6 +165,9 @@ export default function DevTools<TCustomSettings>({
 
   if (!isReady) return <p>Initializing...</p>;
 
+  const hasAppBehaviorChanges =
+    delay !== defaults.delay || customResponses.length > 0;
+
   return (
     <>
       {/* Wrap app in ErrorBoundary so DevTools continue to display upon error */}
@@ -179,6 +182,8 @@ export default function DevTools<TCustomSettings>({
         className={cx(
           "fixed p-4 border shadow-xl max-h-screen overflow-auto bg-white opacity-90",
           {
+            "w-16 h-16": !isOpen,
+            "bg-yellow-100": !isOpen && hasAppBehaviorChanges,
             "bottom-0": position.includes("bottom"),
             "top-0": position.includes("top"),
             "right-0": position.includes("right"),

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,6 +14,8 @@ export default function Button({
         "bg-blue-600 text-white": variant === "primary",
         "bg-white border-none p-1 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100":
           variant === "icon",
+        "absolute inset-0 border-none inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:backdrop-brightness-90":
++         variant === "expander",
       })}
       {...rest}
     />

--- a/src/components/OpenButton.tsx
+++ b/src/components/OpenButton.tsx
@@ -2,7 +2,7 @@ import Button, { ButtonProps } from "./Button";
 
 export default function OpenButton(props: ButtonProps) {
   return (
-    <Button variant="icon" {...props}>
+    <Button variant="expander" {...props}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         className="h-6 w-6"


### PR DESCRIPTION
https://user-images.githubusercontent.com/2754163/183965319-7033aba6-20e1-459c-8884-536b28669b5f.mov

I made a few minor style changes, just based on the experience I had while exploring the demo.

- When the tool is closed, there is a non-clickable "dead zone" on the edges due to padding around the OpenButton, which I removed because visually it all looks like one big button.
- When the tool is closed, I tinted the OpenButton expander yellow to match the changed input fields, if a setting that would change the app's behavior (delays or custom handlers) is applied.
